### PR TITLE
Fixes std::set problem for my Windows

### DIFF
--- a/codegeneration/scripts/templates/Meta_FunctionStringsByExtension.cpp.in
+++ b/codegeneration/scripts/templates/Meta_FunctionStringsByExtension.cpp.in
@@ -9,7 +9,7 @@ using namespace gl; // ToDo: multiple APIs?
 namespace glbinding
 {
 
-const std::unordered_map<GLextension, std::set<std::string>> Meta_FunctionStringsByExtension
+const std::unordered_map<GLextension, std::vector<std::string>> Meta_FunctionStringsByExtension
 {
 #ifdef STRINGS_BY_GL
     %s

--- a/source/glbinding/source/Meta.cpp
+++ b/source/glbinding/source/Meta.cpp
@@ -144,7 +144,7 @@ const std::set<std::string> & Meta::getRequiredFunctions(const GLextension exten
         static const std::set<std::string> none;
         return none;
     }
-    return i->second;
+	return std::set<std::string>(i->second.begin(), i->second.end());
 }
 
 const std::set<GLextension> & Meta::getExtensionsRequiring(const std::string & function)

--- a/source/glbinding/source/Meta_FunctionStringsByExtension.cpp
+++ b/source/glbinding/source/Meta_FunctionStringsByExtension.cpp
@@ -9,7 +9,7 @@ using namespace gl; // ToDo: multiple APIs?
 namespace glbinding
 {
 
-const std::unordered_map<GLextension, std::set<std::string>> Meta_FunctionStringsByExtension
+const std::unordered_map<GLextension, std::vector<std::string>> Meta_FunctionStringsByExtension
 {
 #ifdef STRINGS_BY_GL
     { GLextension::GL_3DFX_tbuffer, { "glTbufferMask3DFX" } },

--- a/source/glbinding/source/Meta_Maps.h
+++ b/source/glbinding/source/Meta_Maps.h
@@ -28,7 +28,7 @@ extern const std::unordered_map<std::string, gl::GLextension> Meta_ExtensionsByS
 extern const std::unordered_map<gl::GLextension, std::string> Meta_StringsByExtension;
 
 extern const std::unordered_map<std::string, std::set<gl::GLextension>> Meta_ExtensionsByFunctionString;
-extern const std::unordered_map<gl::GLextension, std::set<std::string>> Meta_FunctionStringsByExtension;
+extern const std::unordered_map<gl::GLextension, std::vector<std::string>> Meta_FunctionStringsByExtension;
 
 extern const std::unordered_map<gl::GLextension, Version> Meta_ReqVersionsByExtension;
 


### PR DESCRIPTION
- std::set replaced (in one position) by std::vector
  (Windows 7)
