### PR TITLE
implement setSwapInterval() for OS X

### DIFF
--- a/source/examples/cubescape-qt/Canvas.cpp
+++ b/source/examples/cubescape-qt/Canvas.cpp
@@ -3,6 +3,10 @@
 
 #include <cassert>
 
+#ifdef __APPLE__
+#include <OpenGL/OpenGL.h>
+#endif
+
 #include <glbinding/ContextInfo.h>
 #include <glbinding/Version.h>
 
@@ -173,7 +177,13 @@ void Canvas::setSwapInterval(SwapInterval swapInterval)
 
 #elif __APPLE__
 
-    qWarning("ToDo: Setting swap interval is currently not implemented for __APPLE__");
+    CGLContextObj contextObj;
+    GLint swapIntervalParam = swapInterval;
+    
+    contextObj = CGLGetCurrentContext();
+
+    CGLError error = CGLSetParameter(contextObj, kCGLCPSwapInterval, &swapIntervalParam);
+    result = (error == kCGLNoError);
 
 #else
     // ToDo: C++11 - type aliases


### PR DESCRIPTION
hey. this pull request adds the ability to change the swap interval on OS X in the cubescape-qt example. Adaptive vertical synchronization is not supported and results in a normal vertical synchronization.
