### PR TITLE
Fix error: chosen constructor is explicit in copy-initialization.

### DIFF
--- a/source/glbinding/source/ContextInfo.cpp
+++ b/source/glbinding/source/ContextInfo.cpp
@@ -38,7 +38,7 @@ std::set<GLextension> ContextInfo::extensions(std::set<std::string> * unknown)
 
     if (v <= Version(1, 0)) // OpenGL 1.0 doesn't support extensions
     {
-        return {};
+        return std::set<GLextension> {};
     }
 
     std::set<GLextension> extensions;


### PR DESCRIPTION
The following error occured with clang:
.../glbinding/source/glbinding/source/ContextInfo.cpp:41:16: error: chosen constructor is explicit in copy-initialization return {};

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/set:428:14: note: constructor declared here explicit set(const value_compare& __comp = value_compare())

The small change fixxes the error.
