### PR TITLE
Fix clang compilation

### DIFF
--- a/source/glbinding/source/Meta_BitfieldsByString.cpp
+++ b/source/glbinding/source/Meta_BitfieldsByString.cpp
@@ -135,9 +135,9 @@ const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_I =
     { "GL_ITALIC_BIT_NV", static_cast<GLbitfield>(PathRenderingMaskNV::GL_ITALIC_BIT_NV) }
 };
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_J;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_J {};
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_K;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_K {};
 
 const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_L =
 {
@@ -187,7 +187,7 @@ const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_N =
     { "GL_NORMAL_BIT_PGI", static_cast<GLbitfield>(VertexHintsMaskPGI::GL_NORMAL_BIT_PGI) }
 };
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_O;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_O {};
 
 const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_P =
 {
@@ -263,13 +263,13 @@ const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_V =
     { "GL_VIEWPORT_BIT", static_cast<GLbitfield>(AttribMask::GL_VIEWPORT_BIT) }
 };
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_W;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_W {};
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_X;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_X {};
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_Y;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_Y {};
 
-const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_Z;
+const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_Z {};
 
 const std::array<std::unordered_map<std::string, gl::GLbitfield>, 27> Meta_BitfieldsByStringMaps =
 { {

--- a/source/glbinding/source/Meta_EnumsByString.cpp
+++ b/source/glbinding/source/Meta_EnumsByString.cpp
@@ -1724,7 +1724,7 @@ const std::unordered_map<std::string, GLenum> Meta_EnumsByString_I =
     { "GL_IUI_V3F_EXT", GLenum::GL_IUI_V3F_EXT }
 };
 
-const std::unordered_map<std::string, GLenum> Meta_EnumsByString_J;
+const std::unordered_map<std::string, GLenum> Meta_EnumsByString_J {};
 
 const std::unordered_map<std::string, GLenum> Meta_EnumsByString_K =
 {

--- a/source/glbinding/source/Meta_ExtensionsByFunctionString.cpp
+++ b/source/glbinding/source/Meta_ExtensionsByFunctionString.cpp
@@ -10,7 +10,7 @@ using namespace gl; // ToDo: multiple APIs?
 namespace glbinding
 {
 
-const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_0;
+const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_0 {};
 
 const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_A =
 {
@@ -1006,9 +1006,9 @@ const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFu
     { "glIsVertexAttribEnabledAPPLE", { GLextension::GL_APPLE_vertex_program_evaluators } }
 };
 
-const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_J;
+const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_J {};
 
-const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_K;
+const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_K {};
 
 const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_L =
 {
@@ -2317,13 +2317,13 @@ const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFu
     { "glWriteMaskEXT", { GLextension::GL_EXT_vertex_shader } }
 };
 
-const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_X;
+const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_X {};
 
-const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_Y;
+const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_Y {};
 
-const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_Z;
+const std::unordered_map<std::string, std::set<GLextension>> Meta_ExtensionsByFunctionString_Z {};
 
-const std::array<std::unordered_map<std::string, std::set<gl::GLextension>>, 27> Meta_ExtensionsByFunctionStringMaps = 
+const std::array<std::unordered_map<std::string, std::set<gl::GLextension>>, 27> Meta_ExtensionsByFunctionStringMaps =
 { {
     Meta_ExtensionsByFunctionString_0,
     Meta_ExtensionsByFunctionString_A,

--- a/source/glbinding/source/Meta_ExtensionsByString.cpp
+++ b/source/glbinding/source/Meta_ExtensionsByString.cpp
@@ -248,11 +248,11 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_A =
     { "GL_ATI_vertex_streams", GLextension::GL_ATI_vertex_streams }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_B;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_B {};
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_C;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_C {};
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_D;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_D {};
 
 const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_E =
 {
@@ -359,7 +359,7 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_E =
     { "GL_EXT_x11_sync_object", GLextension::GL_EXT_x11_sync_object }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_F;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_F {};
 
 const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_G =
 {
@@ -393,7 +393,7 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_I =
     { "GL_INTEL_performance_query", GLextension::GL_INTEL_performance_query }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_J;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_J {};
 
 const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_K =
 {
@@ -409,7 +409,7 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_K =
     { "GL_KHR_texture_compression_astc_sliced_3d", GLextension::GL_KHR_texture_compression_astc_sliced_3d }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_L;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_L {};
 
 const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_M =
 {
@@ -541,7 +541,7 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_P =
     { "GL_PGI_vertex_hints", GLextension::GL_PGI_vertex_hints }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_Q;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_Q {};
 
 const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_R =
 {
@@ -616,11 +616,11 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_S =
     { "GL_SUN_vertex", GLextension::GL_SUN_vertex }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_T;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_T {};
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_U;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_U {};
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_V;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_V {};
 
 const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_W =
 {
@@ -628,11 +628,11 @@ const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_W =
     { "GL_WIN_specular_fog", GLextension::GL_WIN_specular_fog }
 };
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_X;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_X {};
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_Y;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_Y {};
 
-const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_Z;
+const std::unordered_map<std::string, GLextension> Meta_ExtensionsByString_Z {};
 
 const std::array<std::unordered_map<std::string, gl::GLextension>, 27> Meta_ExtensionsByStringMaps =
 { {


### PR DESCRIPTION
Compilation under clang 3.7 errored with the following message:
```
.../source/glbinding/source/Meta_BitfieldsByString.cpp:138:51: error:
    default initialization of an object of const type 'const
    std::unordered_map<std::string, GLbitfield>' without a user-provided
    default constructor
const std::unordered_map<std::string, GLbitfield> Meta_BitfieldsByString_J;
```
and more equivalent messages