### PR TITLE
Refine cmake find scripts

### DIFF
--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -34,6 +34,13 @@ find_library(GLEW_LIBRARY NAMES GLEW glew glew32 glew32s
     /usr/local
     /sw
     /opt/local
+    /opt/local-release
+    /opt/local-debug
+
+    # authors prefered choice for development
+    /build 
+    /build-release
+    /build-debug
 
     PATH_SUFFIXES
     /lib

--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -34,13 +34,14 @@ find_library(GLEW_LIBRARY NAMES GLEW glew glew32 glew32s
     /usr/local
     /sw
     /opt/local
-    /opt/local-release
-    /opt/local-debug
 
     # authors prefered choice for development
-    /build 
+    /build
     /build-release
     /build-debug
+    $ENV{GLEW_DIR}/build
+    $ENV{GLEW_DIR}/build-release
+    $ENV{GLEW_DIR}/build-debug
 
     PATH_SUFFIXES
     /lib

--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -9,6 +9,7 @@
 find_path(GLEW_INCLUDE_DIR GL/glew.h
 
     PATHS
+    $ENV{GLEW_DIR}
     /usr
     /usr/local
     /sw
@@ -31,6 +32,7 @@ MESSAGE(STATUS "MOEP: /lib/${GLEW_BUILD_DIR}")
 find_library(GLEW_LIBRARY NAMES GLEW glew glew32 glew32s
 
     PATHS
+    $ENV{GLEW_DIR}
     /usr
     /usr/local
     /sw
@@ -39,7 +41,7 @@ find_library(GLEW_LIBRARY NAMES GLEW glew glew32 glew32s
     PATH_SUFFIXES
     /lib
     /lib64
-    /${GLEW_BUILD_DIR}
+    /lib/${GLEW_BUILD_DIR}
 
     DOC "The GLEW library")
 
@@ -51,10 +53,11 @@ if(WIN32)
         ${GLEW_INCLUDE_DIR}/..
 
         PATHS
+        $ENV{GLEW_DIR}
 
         PATH_SUFFIXES
-        /lib
         /bin
+        /bin/${GLEW_BUILD_DIR}
 
         DOC "The GLEW binary")
 

--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -26,9 +26,6 @@ else()
     set(GLEW_BUILD_DIR Release/Win32)
 endif()
 
-MESSAGE(STATUS $ENV{CMAKE_PREFIX_PATH})
-MESSAGE(STATUS "MOEP: /lib/${GLEW_BUILD_DIR}")
-
 find_library(GLEW_LIBRARY NAMES GLEW glew glew32 glew32s
 
     PATHS

--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -7,13 +7,16 @@
 
 
 find_path(GLEW_INCLUDE_DIR GL/glew.h
-    $ENV{GLEWDIR}/include
-    $ENV{GLEW_HOME}/include
-    $ENV{PROGRAMFILES}/GLEW/include
-    /usr/include
-    /usr/local/include
-    /sw/include
-    /opt/local/include
+
+    PATHS
+    /usr
+    /usr/local
+    /sw
+    /opt/local
+
+    PATH_SUFFIXES
+    /include
+
     DOC "The directory where GL/glew.h resides")
 
 if (X64)
@@ -22,33 +25,37 @@ else()
     set(GLEW_BUILD_DIR Release/Win32)
 endif()
 
+MESSAGE(STATUS $ENV{CMAKE_PREFIX_PATH})
+MESSAGE(STATUS "MOEP: /lib/${GLEW_BUILD_DIR}")
 
-find_library(GLEW_LIBRARY
-    NAMES GLEW glew glew32 glew32s
+find_library(GLEW_LIBRARY NAMES GLEW glew glew32 glew32s
+
     PATHS
-    $ENV{GLEWDIR}/lib
-    $ENV{GLEW_HOME}/lib
-    $ENV{GLEWDIR}/lib/${GLEW_BUILD_DIR}
-    $ENV{GLEW_HOME}/lib/${GLEW_BUILD_DIR}
-    /usr/lib64
-    /usr/local/lib64
-    /sw/lib64
-    /opt/local/lib64
-    /usr/lib
-    /usr/local/lib
-    /sw/lib
-    /opt/local/lib
+    /usr
+    /usr/local
+    /sw
+    /opt/local
+
+    PATH_SUFFIXES
+    /lib
+    /lib64
+    /${GLEW_BUILD_DIR}
+
     DOC "The GLEW library")
 
 if(WIN32)
 
-    find_file(GLEW_BINARY
-        NAMES glew32.dll glew32s.dll
+    find_file(GLEW_BINARY NAMES glew32.dll glew32s.dll
+
+        HINTS
+        ${GLEW_INCLUDE_DIR}/..
+
         PATHS
-        $ENV{GLEWDIR}/bin
-        $ENV{GLEW_HOME}/bin
-        $ENV{GLEWDIR}/bin/${GLEW_BUILD_DIR}
-        $ENV{GLEW_HOME}/bin/${GLEW_BUILD_DIR}
+
+        PATH_SUFFIXES
+        /lib
+        /bin
+
         DOC "The GLEW binary")
 
 endif()

--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -33,17 +33,17 @@ find_library(GLFW_LIBRARY NAMES glfw3 glfw glfw3dll glfwdll
     /usr/local
     /sw
     /opt/local
-    /opt/local-release
-    /opt/local-debug
 
     # authors prefered choice for development
-    /build 
-    /build-release
-    /build-debug
+    $ENV{GLFW_DIR}
+    $ENV{GLFW_DIR}/build
+    $ENV{GLFW_DIR}/build-release
+    $ENV{GLFW_DIR}/build-debug
 
     PATH_SUFFIXES
     /lib
     /lib64
+    /src # for from-source builds
 
     DOC "The GLFW library")
     

--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -33,6 +33,13 @@ find_library(GLFW_LIBRARY NAMES glfw3 glfw glfw3dll glfwdll
     /usr/local
     /sw
     /opt/local
+    /opt/local-release
+    /opt/local-debug
+
+    # authors prefered choice for development
+    /build 
+    /build-release
+    /build-debug
 
     PATH_SUFFIXES
     /lib

--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -3,59 +3,58 @@
 # GLFW_INCLUDE_DIR
 # GLFW_LIBRARY
 
-find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h
-    $ENV{GLFWDIR}/include
-    $ENV{GLFW_HOME}/include
-    $ENV{PROGRAMFILES}/GLFW/include
-    ${OPENGL_INCLUDE_DIR}
-    /usr/include
-    /usr/local/include
-    /usr/include/GL
-    /sw/include
-    /opt/local/include
-    /opt/graphics/OpenGL/include
-    /opt/graphics/OpenGL/contrib/libglfw
-    DOC "The directory where GL/glfw.h resides"
-)
+# GLFW_BINARY (win32 only)
 
-find_library(GLFW_LIBRARY
-    NAMES glfw3 glfw glfw3dll glfwdll
+
+find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h
+
+    PATHS
+    ${OPENGL_INCLUDE_DIR}
+    /usr
+    /usr/local
+    /usr/include/GL
+    /sw
+    /opt/local
+    /opt/graphics/OpenGL
+    /opt/graphics/OpenGL/contrib/libglfw
+
+    PATH_SUFFIXES
+    /include
+
+    DOC "The directory where GLFW/glfw.h resides")
+
+find_library(GLFW_LIBRARY NAMES glfw3 glfw glfw3dll glfwdll
+
     PATHS
     ${GLFW_LIBRARY_DIR}  # provided by glfw config
-    $ENV{GLFWDIR}/lib
-    $ENV{GLFWDIR}/lib/x64
-    $ENV{GLFWDIR}/lib/cocoa
-    $ENV{GLFWDIR}/lib-msvc120
-    $ENV{GLFW_HOME}/lib
-    $ENV{GLFW_HOME}/lib/x64
-    $ENV{GLFW_HOME}/lib/cocoa
-    $ENV{GLFW_HOME}/lib-msvc120
-    $ENV{PROGRAMFILES}/GLFW/lib
-    $ENV{PROGRAMFILES}/GLFW/lib/x64
-    $ENV{PROGRAMFILES}/GLFW/lib-msvc120
-    $ENV{GLFW_HOME}/build/src
-    $ENV{GLFW_HOME}/build-debug/src
-    $ENV{GLFW_HOME}/build-release/src
-    /usr/lib64
-    /usr/local/lib64
-    /sw/lib64
-    /opt/local/lib64
-    /usr/lib
-    /usr/local/lib
-    /sw/lib
-    /opt/local/lib
-    DOC "The GLFW library"
-)
+    /lib/x64
+    /lib/cocoa
+    /usr
+    /usr/local
+    /sw
+    /opt/local
+
+    PATH_SUFFIXES
+    /lib
+    /lib64
+
+    DOC "The GLFW library")
     
 if(WIN32)
 
-    find_file(GLFW_BINARY
-        NAMES glfw3.dll
+    find_file(GLFW_BINARY glfw3.dll
+
+        HINTS
+        ${GLFW_INCLUDE_DIR}/..
+
         PATHS
-        $ENV{GLFWDIR}/bin
-        $ENV{GLFW_HOME}/bin
-        $ENV{GLFWDIR}/bin/${GLFW_BUILD_DIR}
-        $ENV{GLFW_HOME}/bin/${GLFW_BUILD_DIR}
+        /lib/x64
+        /lib/cocoa
+
+        PATH_SUFFIXES
+        /lib
+        /bin
+
         DOC "The GLFW binary")
 
 endif()

--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -9,7 +9,7 @@
 find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h
 
     PATHS
-    ${OPENGL_INCLUDE_DIR}
+    $ENV{GLFW_DIR}
     /usr
     /usr/local
     /usr/include/GL
@@ -26,7 +26,7 @@ find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h
 find_library(GLFW_LIBRARY NAMES glfw3 glfw glfw3dll glfwdll
 
     PATHS
-    ${GLFW_LIBRARY_DIR}  # provided by glfw config
+    $ENV{GLFW_DIR}
     /lib/x64
     /lib/cocoa
     /usr
@@ -48,6 +48,7 @@ if(WIN32)
         ${GLFW_INCLUDE_DIR}/..
 
         PATHS
+        $ENV{GLFW_DIR}
         /lib/x64
         /lib/cocoa
 

--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -35,7 +35,9 @@ find_library(GLFW_LIBRARY NAMES glfw3 glfw glfw3dll glfwdll
     /opt/local
 
     # authors prefered choice for development
-    $ENV{GLFW_DIR}
+    /build
+    /build-release
+    /build-debug
     $ENV{GLFW_DIR}/build
     $ENV{GLFW_DIR}/build-release
     $ENV{GLFW_DIR}/build-debug

--- a/source/examples/cubescape-qt/CMakeLists.txt
+++ b/source/examples/cubescape-qt/CMakeLists.txt
@@ -3,9 +3,9 @@
 # External dependencies
 # 
 
-find_package(Qt5Core    5.0)
-find_package(Qt5Gui     5.0)
-find_package(Qt5Widgets 5.0)
+find_package(Qt5Core    5.1)
+find_package(Qt5Gui     5.1)
+find_package(Qt5Widgets 5.1)
 
 # Enable automoc
 set(CMAKE_AUTOMOC ON)

--- a/source/examples/cubescape-qt/CMakeLists.txt
+++ b/source/examples/cubescape-qt/CMakeLists.txt
@@ -3,9 +3,9 @@
 # External dependencies
 # 
 
-find_package(Qt5Core    5.1)
-find_package(Qt5Gui     5.1)
-find_package(Qt5Widgets 5.1)
+find_package(Qt5Core    5.0)
+find_package(Qt5Gui     5.0)
+find_package(Qt5Widgets 5.0)
 
 # Enable automoc
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
* Since there are no official glew and glfw installers there are no default environment variables to expect, except the cmake _DIR default. Hence, rely on ```CMAKE_PREFIX_PATH``` (favor best-practice here)
* correctly discern between ```HINTS``` and ```PATHS```
* take advantage of ```PATH_SUFFIXES```
* remove all unknown/undocumented paths