### PR TITLE
Fix race on AbstractFunction state vector

### DIFF
--- a/source/glbinding/source/Binding.cpp
+++ b/source/glbinding/source/Binding.cpp
@@ -76,7 +76,11 @@ void Binding::initialize(
         useContext(context);
 
     if (_resolveFunctions)
+    {
+        g_mutex.lock();
         resolveFunctions();
+        g_mutex.unlock();
+    }
 
     // restore previous context
     if(resolveWOUse)


### PR DESCRIPTION
If two threads call Binding::initialize() at roughly the same time,
one thread can write to a stale AbstractFunction state pointer during
function resolution just after the other thread reallocates m_states
in AbstractFunction::provideState().