### PR TITLE
No exceptions (closes #157)

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -86,6 +86,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
         /GF           # -> enable string pooling
         >
     )
+
 endif ()
 
 # GCC and Clang compiler options

--- a/source/glbinding/CMakeLists.txt
+++ b/source/glbinding/CMakeLists.txt
@@ -144,6 +144,14 @@ source_group_by_path(${source_path}  "\\\\.cpp$|\\\\.c$|\\\\.h$|\\\\.inl$"
 # Create library
 # 
 
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+
+    # workaround for removing default flags 
+    string(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+endif ()
+
+
 # Build library
 add_library(${target}
     ${sources}
@@ -232,6 +240,7 @@ target_link_libraries(${target}
 
 target_compile_definitions(${target}
     PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:_HAS_EXCEPTIONS=0>
 
     PUBLIC
     $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${target_upper}_STATIC_DEFINE>


### PR DESCRIPTION
For MSVC:
* Disable exceptions again (for glbinding library only)
* Therefore also disable exception for use of stl within glbinding library