### PR TITLE
Set versioning properties. Closes #200

### DIFF
--- a/source/glbinding/CMakeLists.txt
+++ b/source/glbinding/CMakeLists.txt
@@ -196,6 +196,8 @@ set_target_properties(${target}
     PROPERTIES
     ${DEFAULT_PROJECT_OPTIONS}
     FOLDER "${IDE_FOLDER}"
+    VERSION ${META_VERSION}
+    SOVERSION 0
 )
 
 


### PR DESCRIPTION
Gbp-Pq: Name Set-versioning-properties.patch

This PR addresses the issue detailed in #200. The installation now creates the necessary versioning symlinks  libglbinding.so -> libglbinding.so.0 ->  libglbinding.so.2.1.1.
