### PR TITLE
make it more robust to building with glfw in parallel dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ file(WRITE "${PROJECT_BINARY_DIR}/VERSION" "${META_NAME_VERSION}")
 
 include(cmake/CompileOptions.cmake)
 
+# IDE visibility for cmake build files
+add_subdirectory(cmake)
 
 # 
 # Deployment/installation setup

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,29 @@
+
+set(cmake_files 
+	CheckTemplate.cmake
+	CompileOptions.cmake
+	ComponentInstall.cmake
+	Custom.cmake
+	FindGLEW.cmake
+	FindGLFW.cmake
+	GetGitRevisionDescription.cmake
+	RuntimeDependencies.cmake
+	GetGitRevisionDescription.cmake.in
+	CMakeLists.txt
+)
+
+######################################################
+
+set(show_cmd  "dir")
+if(NOT WIN32)
+	set(show_cmd  "ls")
+endif()
+    
+add_custom_target(glbinding_cmake
+   COMMAND  echo "${cmake_files}"
+   COMMAND  ${show_cmd} 
+   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+   COMMENT "[dummy target puts files into IDE view...]"
+   SOURCES  ${cmake_files}
+   VERBATIM
+   )

--- a/cmake/FindGLFW.cmake
+++ b/cmake/FindGLFW.cmake
@@ -20,7 +20,7 @@ find_path(GLFW_INCLUDE_DIR GLFW/glfw3.h
     /opt/local
     /opt/graphics/OpenGL
     /opt/graphics/OpenGL/contrib/libglfw
-
+    
     PATH_SUFFIXES
     /include
 
@@ -121,3 +121,21 @@ endif()
 
 find_package_handle_standard_args(GLFW DEFAULT_MSG GLFW_LIBRARIES GLFW_INCLUDE_DIR)
 mark_as_advanced(GLFW_FOUND GLFW_INCLUDE_DIR GLFW_LIBRARIES)
+
+
+# Are we building glfw, e.g. in a parallel git submodule directory that was included prior? 
+if(TARGET    glfw)
+    set( GLFW_LIBRARIES  glfw )
+    set( GLFW_FOUND      TRUE)    
+    if( DEFINED GLFW_SOURCE_DIR)
+        if( EXISTS ${GLFW_SOURCE_DIR} )
+            set(GLFW_INCLUDE_DIR ${GLFW_SOURCE_DIR}/include)
+        endif()
+    endif()
+   
+    message(STATUS  "GLFW_LIBRARIES  =${GLFW_LIBRARIES}, \n"
+                    "GLFW_FOUND      =${GLFW_FOUND}, \n"
+                    "GLFW_INCLUDE_DIR=${GLFW_INCLUDE_DIR}\n")
+endif()
+
+

--- a/source/tools/CMakeLists.txt
+++ b/source/tools/CMakeLists.txt
@@ -4,9 +4,21 @@ if(NOT OPTION_BUILD_TOOLS)
     return()
 endif()
 
+# Convenience target to build all tools (and no other projects)
+add_custom_target( glbinding_ToolsALL )
 
-# Tools
-add_subdirectory("glcontexts")
-add_subdirectory("glfunctions")
-add_subdirectory("glmeta")
-add_subdirectory("glqueries")
+# Loop thru All Tools
+foreach( tool       glcontexts
+                    glfunctions
+                    glmeta
+                    glqueries 
+        )
+
+    add_subdirectory( "${tool}")
+    if(TARGET ${tool})
+        add_dependencies( glbinding_ToolsALL  ${tool} )
+    endif()
+endforeach()
+
+
+                 


### PR DESCRIPTION
- if glfw is a target in the project (e.g. when glbinding + glfw are both submodules and glfw comes first), allow using the build's glfw target. 
- allow a '--visible' mode for glcontexts example, to verify things are sane with windowing and glfw