### PR TITLE
Add GLBINDING_USE_BOOST_THREAD for MinGW (closes #224)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,5 @@ Ryp
 sebastiankaybelle
 Somae
 talknomoney66
+StephanTLavavej
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ option(OPTION_BUILD_GPU_TESTS         "Build tests that require an OpenGL contex
 option(OPTION_BUILD_DOCS              "Build documentation."                                   OFF)
 option(OPTION_BUILD_TOOLS             "Build tools."                                           ON)
 option(OPTION_BUILD_EXAMPLES          "Build examples."                                        OFF)
-option(OPTION_BUILD_WITH_BOOST_THREAD "Use std::regex instead of boost"                        OFF)
+option(OPTION_BUILD_WITH_BOOST_THREAD "Use boost::thread instead of std::thread."              OFF)
 
 
 # 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,13 +70,14 @@ string(TOUPPER ${META_PROJECT_ID} META_PROJECT_ID)
 # 
 
 # Project options
-option(BUILD_SHARED_LIBS      "Build shared instead of static libraries."              ON)
-option(OPTION_SELF_CONTAINED  "Create a self-contained install with all dependencies." OFF)
-option(OPTION_BUILD_TESTS     "Build tests."                                           ON)
-option(OPTION_BUILD_GPU_TESTS "Build tests that require an OpenGL context."            ON)
-option(OPTION_BUILD_DOCS      "Build documentation."                                   OFF)
-option(OPTION_BUILD_TOOLS     "Build tools."                                           ON)
-option(OPTION_BUILD_EXAMPLES  "Build examples."                                        OFF)
+option(BUILD_SHARED_LIBS              "Build shared instead of static libraries."              ON)
+option(OPTION_SELF_CONTAINED          "Create a self-contained install with all dependencies." OFF)
+option(OPTION_BUILD_TESTS             "Build tests."                                           ON)
+option(OPTION_BUILD_GPU_TESTS         "Build tests that require an OpenGL context."            ON)
+option(OPTION_BUILD_DOCS              "Build documentation."                                   OFF)
+option(OPTION_BUILD_TOOLS             "Build tools."                                           ON)
+option(OPTION_BUILD_EXAMPLES          "Build examples."                                        OFF)
+option(OPTION_BUILD_WITH_BOOST_THREAD "Use std::regex instead of boost"                        OFF)
 
 
 # 

--- a/source/glbinding/CMakeLists.txt
+++ b/source/glbinding/CMakeLists.txt
@@ -275,7 +275,7 @@ target_compile_definitions(${target}
     # since we use stl and stl is intended to use exceptions, exceptions should not be disabled
     # furthermore, this flag is not officially supported
     #$<$<CXX_COMPILER_ID:MSVC>:_HAS_EXCEPTIONS=0> 
-    $<$<BOOL:${OPTION_BUILD_WITH_BOOST_THREAD}>:GLBINDING_USE_BOOST_THREAD>
+    $<$<AND:$<BOOL:${OPTION_BUILD_WITH_BOOST_THREAD}>,$<BOOL:${Boost_FOUND}>>:GLBINDING_USE_BOOST_THREAD>
 
     PUBLIC
     $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${target_id}_STATIC_DEFINE>

--- a/source/glbinding/CMakeLists.txt
+++ b/source/glbinding/CMakeLists.txt
@@ -5,6 +5,22 @@
 
 find_package(OpenGL REQUIRED)
 
+set(ADDITIONAL_LIBRARIES)
+set(ADDITIONAL_INCLUDES)
+if(OPTION_BUILD_WITH_BOOST_THREAD)
+    find_package(Boost COMPONENTS thread REQUIRED)
+    
+    if (Boost_FOUND)
+        message(STATUS "Use Boost for thread.")
+        
+        set(ADDITIONAL_LIBRARIES ${ADDITIONAL_LIBRARIES} ${Boost_LIBRARIES})
+        set(ADDITIONAL_INCLUDES ${ADDITIONAL_INCLUDES} ${Boost_INCLUDE_DIRS})
+    else()
+        message(WARNING "OPTION_BUILD_WITH_BOOST_THREAD is set to On: Boost not found.")
+        message(WARNING "Defaulting to C++11 thread.")
+    endif()
+endif()
+
 # 
 # Library name and options
 # 
@@ -222,6 +238,7 @@ target_include_directories(${target}
     ${PROJECT_BINARY_DIR}/source/include
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${ADDITIONAL_INCLUDES}
 
     PUBLIC
     ${DEFAULT_INCLUDE_DIRECTORIES}
@@ -239,6 +256,7 @@ target_include_directories(${target}
 
 target_link_libraries(${target}
     PRIVATE
+    ${ADDITIONAL_LIBRARIES}
 
     PUBLIC
     ${DEFAULT_LIBRARIES}
@@ -257,6 +275,7 @@ target_compile_definitions(${target}
     # since we use stl and stl is intended to use exceptions, exceptions should not be disabled
     # furthermore, this flag is not officially supported
     #$<$<CXX_COMPILER_ID:MSVC>:_HAS_EXCEPTIONS=0> 
+    $<$<BOOL:${OPTION_BUILD_WITH_BOOST_THREAD}>:GLBINDING_USE_BOOST_THREAD>
 
     PUBLIC
     $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:${target_id}_STATIC_DEFINE>

--- a/source/glbinding/source/RingBuffer.inl
+++ b/source/glbinding/source/RingBuffer.inl
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <iomanip>
-#include <thread>
 #include <iterator>
 #include <cassert>
 #include <cmath>

--- a/source/glbinding/source/logging.cpp
+++ b/source/glbinding/source/logging.cpp
@@ -3,11 +3,20 @@
 
 #include <array>
 #include <atomic>
-#include <condition_variable>
+#include <chrono>
 #include <fstream>
-#include <mutex>
 #include <sstream>
+
+#ifdef GLBINDING_USE_BOOST_THREAD
+#include <boost/chrono.hpp>
+#include <boost/thread.hpp>
+namespace std_boost = boost;
+#else
+#include <condition_variable>
+#include <mutex>
 #include <thread>
+namespace std_boost = std;
+#endif
 
 #include "logging_private.h"
 #include "RingBuffer.h"
@@ -20,8 +29,8 @@ const unsigned int LOG_BUFFER_SIZE = 5000;
 
 std::atomic<bool> g_stop{false};
 std::atomic<bool> g_persisted{true};
-std::mutex g_lockfinish;
-std::condition_variable g_finishcheck;
+std_boost::mutex g_lockfinish;
+std_boost::condition_variable g_finishcheck;
 
 using FunctionCallBuffer = glbinding::RingBuffer<glbinding::logging::LogEntry>;
 FunctionCallBuffer g_buffer{LOG_BUFFER_SIZE};
@@ -74,7 +83,7 @@ void stop()
     removeCallbackMask(CallbackMask::Logging);
 
     g_stop = true;
-    std::unique_lock<std::mutex> locker(g_lockfinish);
+    std_boost::unique_lock<std_boost::mutex> locker(g_lockfinish);
 
     // Spurious wake-ups: http://www.codeproject.com/Articles/598695/Cplusplus-threads-locks-and-condition-variables
     while(!g_persisted)
@@ -100,7 +109,7 @@ void log(FunctionCall * call)
 
     while (!available)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std_boost::this_thread::sleep_for(std_boost::chrono::milliseconds(1));
         next = g_buffer.nextHead(available);
     }
 
@@ -115,7 +124,7 @@ void startWriter(const std::string & filepath)
     g_stop = false;
     g_persisted = false;
 
-    std::thread writer([filepath]()
+    std_boost::thread writer([filepath]()
     {
         const auto key = g_buffer.addTail();
         std::ofstream logfile;
@@ -133,7 +142,7 @@ void startWriter(const std::string & filepath)
 
             logfile.flush();
 
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            std_boost::this_thread::sleep_for(std_boost::chrono::milliseconds(1));
         }
 
         logfile.close();


### PR DESCRIPTION
See cginternals/glbinding#224.

Currently, this macro is expected to be defined manually when building glbinding for MinGW without pthreads. The `std_boost` namespace alias makes it a fairly non-intrusive change.

This doesn't attempt to fix test code or tool code. (Notably, the glmeta tool is explicitly linking with pthreads for MinGW.)

RingBuffer.inl was including `<thread>` unnecessarily.

logging.cpp wasn't explicitly including `<chrono>`, despite using its machinery. (Note that Boost.Chrono must additionally be used when communicating with Boost.Thread.)