### PR TITLE
add /usr/local/include to include dir for FreeBSD

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -33,7 +33,7 @@ set(DEFAULT_PROJECT_OPTIONS
 set(DEFAULT_INCLUDE_DIRECTORIES)
 
 if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    include_directories("/usr/local/include")
+    LIST(APPEND DEFAULT_INCLUDE_DIRECTORIES "/usr/local/include")
 endif ()
 
 

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -32,6 +32,10 @@ set(DEFAULT_PROJECT_OPTIONS
 
 set(DEFAULT_INCLUDE_DIRECTORIES)
 
+if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    include_directories("/usr/local/include")
+endif ()
+
 
 # 
 # Libraries


### PR DESCRIPTION
Add /usr/local/include dir to include dir that is default dir for the 3rd party software for FreeBSD.
I don't know an appropriate place to put these lines, but these must be placed somewhere for compiling glbinding on FreeBSD.