### PR TITLE
Fix Cubescape compilation on Windows

### DIFF
--- a/source/examples/cubescape-qt/Painter.cpp
+++ b/source/examples/cubescape-qt/Painter.cpp
@@ -19,7 +19,7 @@ Painter::~Painter()
     delete m_cubescape;
 }
 
-void Painter::initialize(GetProcAddress procAddressCallback)
+void Painter::initialize(ProcAddressGetter procAddressCallback)
 {
     if (m_initialized)
         return;

--- a/source/examples/cubescape-qt/Painter.h
+++ b/source/examples/cubescape-qt/Painter.h
@@ -13,7 +13,7 @@ class CubeScape;
 //       now the QOpenGLContext is tightly coupled with qopengl.h and QOpenGLFunctions.
 
 using ProcAddress = void(*)();
-using GetProcAddress = std::function<ProcAddress(const char *)>;
+using ProcAddressGetter = std::function<ProcAddress(const char *)>;
 
 class Painter
 {
@@ -21,7 +21,7 @@ public:
     Painter();
     ~Painter();
 
-    void initialize(GetProcAddress procAddressCallback);
+    void initialize(ProcAddressGetter procAddressCallback);
 
     void resize(int width, int height);
     void draw();


### PR DESCRIPTION
Name collision for "GetProcAddress"