### PR TITLE
Fix compilation with MSVC 2013

### DIFF
--- a/source/examples/cubescape-qt/Painter.cpp
+++ b/source/examples/cubescape-qt/Painter.cpp
@@ -24,7 +24,7 @@ void Painter::initialize(ProcAddressGetter procAddressCallback)
     if (m_initialized)
         return;
 
-    glbinding::Binding::initialize(procAddressCallback, false); // only resolve functions that are actually used (lazy)
+    glbinding::Binding::initialize(procAddressCallback.target<ProcAddress(const char*)>(), false); // only resolve functions that are actually used (lazy)
 
     m_cubescape = new CubeScape();
 

--- a/source/glbinding/include/glbinding/ProcAddress.h
+++ b/source/glbinding/include/glbinding/ProcAddress.h
@@ -21,7 +21,8 @@ using ProcAddress = void(*)();
 *  @brief
 *    The signature for the getProcAddress function
 */
-using GetProcAddress = std::function<ProcAddress(const char*)>;
+//using GetProcAddress = std::function<ProcAddress(const char*)>;
+using GetProcAddress = ProcAddress(*)(const char*);
 
 
 } // namespace glbinding

--- a/source/glbinding/source/Binding.cpp
+++ b/source/glbinding/source/Binding.cpp
@@ -395,7 +395,7 @@ Binding::FunctionLogCallback & Binding::s_logCallback()
 
 int & Binding::s_pos()
 {
-    GLBINDING_THREAD_LOCAL int pos = 0;
+    GLBINDING_THREAD_LOCAL static int pos = 0;
     //static int pos = 0;
 
     return pos;
@@ -403,7 +403,7 @@ int & Binding::s_pos()
 
 ContextHandle & Binding::s_context()
 {
-    GLBINDING_THREAD_LOCAL ContextHandle context = 0;
+    GLBINDING_THREAD_LOCAL static ContextHandle context = 0;
     //static ContextHandle context = 0;
 
     return context;
@@ -411,7 +411,7 @@ ContextHandle & Binding::s_context()
 
 glbinding::GetProcAddress & Binding::s_getProcAddress()
 {
-    GLBINDING_THREAD_LOCAL glbinding::GetProcAddress getProcAddress = nullptr;
+    GLBINDING_THREAD_LOCAL static glbinding::GetProcAddress getProcAddress = nullptr;
     //static glbinding::GetProcAddress getProcAddress = nullptr;
 
     return getProcAddress;


### PR DESCRIPTION
  - Add "static" behind "GLBINDING_THREAD_LOCAL" (C2480)
  - Use plain function pointer for GetProcAddress (C2483)
  - Fix ambiguous overload for Binding::initialize() (C2666)