### PR TITLE
Fix missing <string> necessary to use std::string in glbinding.h

### DIFF
--- a/source/glbinding/include/glbinding/glbinding.h
+++ b/source/glbinding/include/glbinding/glbinding.h
@@ -2,9 +2,10 @@
 #pragma once
 
 
-#include <set>
-#include <vector>
 #include <functional>
+#include <set>
+#include <string>
+#include <vector>
 
 #include <glbinding/glbinding_api.h>
 #include <glbinding/glbinding_features.h>


### PR DESCRIPTION
This resolves build failures in VS 2019 previews where vector no longer includes string.