### PR TITLE
Fix Visual studio 2019 compile

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -44,4 +44,4 @@ endif()
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/${META_PROJECT_NAME} DESTINATION include COMPONENT dev)
 
 
-include("${CMAKE_SOURCE_DIR}/cmake/WinInstallHacks.cmake")
+include(${PROJECT_SOURCE_DIR}/cmake/WinInstallHacks.cmake)

--- a/source/glbinding/include/glbinding/glbinding.h
+++ b/source/glbinding/include/glbinding/glbinding.h
@@ -3,6 +3,7 @@
 
 
 #include <set>
+#include <string>
 #include <vector>
 #include <functional>
 


### PR DESCRIPTION
Add include missing for Visual Studio 2019.
Fix:
>glbinding\source\glbinding\include\glbinding/glbinding.h(102): error C2039: 'string' : n'est pas membre de 'std' (compilation du fichier source H:\Git\Vita3K-Dante\src\external\glbinding\source\glbinding\source\glbinding.cpp)
2>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.20.27508\include\functional(23): note: voir la déclaration de 'std'

Same on 122/142 line

Fix also path wrong for WinInstallHacks.cmake file not found with using glbinding like submodule, it using before root of project and no root submodule glbinding folder and that is wrong.

Compile tested and succes now on Visual Studio 2019 (on debug mode only, look issue https://github.com/cginternals/glbinding/issues/289 for more information) with using project only or with using it on submodule on other project (like vita3K) 