### PR TITLE
Add a destroy method for destroying the internal library state

### DIFF
--- a/source/glbinding/include/glbinding/Binding.h
+++ b/source/glbinding/include/glbinding/Binding.h
@@ -122,6 +122,12 @@ public:
 
     /**
     *  @brief
+    *    Destroys the internal state
+    */
+    static void destroy();
+
+    /**
+    *  @brief
     *    Registers an additional function for the additional features
     *
     *  @param[in] function

--- a/source/glbinding/include/glbinding/glbinding.h
+++ b/source/glbinding/include/glbinding/glbinding.h
@@ -81,6 +81,12 @@ GLBINDING_API void initialize(ContextHandle context, glbinding::GetProcAddress f
 
 /**
 *  @brief
+*    Destroys the internal state
+*/
+GLBINDING_API void destroy();
+
+/**
+*  @brief
 *    Update the current context state in glbinding
 *
 *  @remark

--- a/source/glbinding/source/Binding.cpp
+++ b/source/glbinding/source/Binding.cpp
@@ -207,6 +207,24 @@ void Binding::initialize(
     }
 }
 
+void Binding::destroy()
+{
+    std_boost::lock_guard<std_boost::recursive_mutex> lock(s_mutex());
+
+    s_maxPos() = -1;
+    s_additionalFunctions() = {};
+    s_contextSwitchCallbacks() = {};
+    s_unresolvedCallback() = {};
+    s_beforeCallback() = {};
+    s_afterCallback() = {};
+    s_logCallback() = {};
+    s_pos() = {};
+    s_context() = {};
+    s_getProcAddress() = {};
+    s_bindings() = {};
+    s_firstGetProcAddress() = {};
+}
+
 ProcAddress Binding::resolveFunction(const char * name)
 {
     if (s_getProcAddress() != nullptr)

--- a/source/glbinding/source/glbinding.cpp
+++ b/source/glbinding/source/glbinding.cpp
@@ -20,6 +20,11 @@ void initialize(ContextHandle context, glbinding::GetProcAddress functionPointer
     Binding::initialize(context, functionPointerResolver, useContext, resolveFunctions);
 }
 
+void destroy()
+{
+    Binding::destroy();
+}
+
 void useCurrentContext()
 {
     Binding::useCurrentContext();


### PR DESCRIPTION
* This is required if we build glbinding as shared library and unload it.
  Otherwise it might be possible that the internal std::functions
  reference memory which might not be accessible anymore.

The `destroy` API function makes it possible to cleanup the internal library state safely,
it does not cleanup any resources.

This is required because we are allowed to pass `std::function` like callables to the API which have a vtable that is placed inside the users code and could be possibly kept referenced while the user code was unloaded already.

In the end it leads to a crash because the corresponding vtable placed in the users shared library is not present anymore on destruction of the glbinding library, because the using library was destroyed beforehand.

The main issue is that we can't reset `s_firstGetProcAddress()` properly when it was set initially because of:

https://github.com/cginternals/glbinding/blob/2bcfb663651e0255db41690b0585baa5c8c29aab/source/glbinding/source/Binding.cpp#L172-L177

Maybe it could be also useful to provide a method for destroying the `thread_local` state of a calling thread, but it should be cleaned up when the corresponding thread exits anyway.