### PR TITLE
Remove memory allocation from logging callback invocation

### DIFF
--- a/source/glbinding-aux/include/glbinding-aux/logging.h
+++ b/source/glbinding-aux/include/glbinding-aux/logging.h
@@ -98,7 +98,7 @@ GLBINDING_AUX_API void resume();
 *  @remark
 *    This function is intended to get used by glbinding and not by a user of glbinding
 */
-GLBINDING_AUX_API void log(LogEntry call);
+GLBINDING_AUX_API void log(FunctionCall && call);
 
 
 } } // namespace glbinding::aux

--- a/source/glbinding-aux/source/logging.cpp
+++ b/source/glbinding-aux/source/logging.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <fstream>
 #include <sstream>
+#include <utility>
 
 #ifdef GLBINDING_USE_BOOST_THREAD
 #include <boost/chrono.hpp>
@@ -148,7 +149,7 @@ void resume()
     glbinding::addCallbackMask(CallbackMask::Timestamp | CallbackMask::Logging);
 }
 
-void log(LogEntry call)
+void log(FunctionCall && call)
 {
     auto available = false;
     auto next = g_buffer.nextHead(available);
@@ -162,7 +163,7 @@ void log(LogEntry call)
     assert(!g_buffer.isFull());
 
     delete next;
-    g_buffer.push(call);
+    g_buffer.push(new FunctionCall(std::move(call)));
 }
 
 void startWriter(const std::string & filepath)

--- a/source/glbinding/include/glbinding/Binding.h
+++ b/source/glbinding/include/glbinding/Binding.h
@@ -60,7 +60,7 @@ public:
     *  @brief
     *    The callback type of a function log callback with parameters and return value
     */
-    using FunctionLogCallback = std::function<void(FunctionCall *)>;
+    using FunctionLogCallback = std::function<void(FunctionCall &&)>;
 
     using ContextSwitchCallback = std::function<void(ContextHandle)>;   ///< The signature of the context switch callback
     

--- a/source/glbinding/include/glbinding/glbinding.h
+++ b/source/glbinding/include/glbinding/glbinding.h
@@ -25,7 +25,7 @@ class FunctionCall;
 
 using SimpleFunctionCallback = std::function<void(const AbstractFunction &)>; ///< The signature of the unresolved callback
 using FunctionCallback = std::function<void(const FunctionCall &)>;           ///< The signature of the before and after callbacks
-using FunctionLogCallback = std::function<void(FunctionCall *)>;              ///< The signature of the log callback
+using FunctionLogCallback = std::function<void(FunctionCall &&)>;             ///< The signature of the log callback
 using ContextSwitchCallback = std::function<void(ContextHandle)>;             ///< The signature of the context switch callback
 
 /**

--- a/source/glbinding/source/Binding.cpp
+++ b/source/glbinding/source/Binding.cpp
@@ -138,7 +138,7 @@ void Binding::log(FunctionCall && call)
 {
     if (s_logCallback())
     {
-        s_logCallback()(new FunctionCall(std::move(call)));
+        s_logCallback()(std::move(call));
     }
 }
 


### PR DESCRIPTION
Currently, implementation of `Binding::log` allocates a move-constructed `FunctionCall` on each invocation and passes a raw pointer to the callback. There are 2 issues with this: 
- The interface does not tell the user that they have to `delete` the allocated object; 
- The allocation itself is unnecessary and is _forced_ from the side of the library. 

I was personally experiencing memory leaks when setting my own logging callback, until I figured out the first part; the second part just generally impacts performance in real-time scenarios.

This PR changes the callback signature from `void(FunctionCall*)` to `void(FunctionCall&&)`; implementation of `Binding::log` now just moves the call further to the callback. The builtin aux logging callback that relied on dynamic allocation is modified to reflect the change.