### PR TITLE
cubescape-qt: Invert result of glXSwapIntervalSGI

### DIFF
--- a/source/examples/cubescape-qt/Canvas.cpp
+++ b/source/examples/cubescape-qt/Canvas.cpp
@@ -207,7 +207,7 @@ void Canvas::setSwapInterval(SwapInterval swapInterval)
     if (!glXSwapIntervalSGI)
         glXSwapIntervalSGI = reinterpret_cast<SWAPINTERVALEXTPROC>(m_context->getProcAddress("glXSwapIntervalSGI"));
     if (glXSwapIntervalSGI)
-        result = glXSwapIntervalSGI(swapInterval);
+        result = !glXSwapIntervalSGI(swapInterval);
 
 #endif
 


### PR DESCRIPTION
Unlike `wglSwapIntervalEXT`, it returns zero on success and non-zero on error. Fixes output being the opposite of actual results on Linux.