### PR TITLE
Fix multicontext and multithreaded tests, add them to suite

### DIFF
--- a/source/tests/glbinding-test/CMakeLists.txt
+++ b/source/tests/glbinding-test/CMakeLists.txt
@@ -32,6 +32,8 @@ set(sources
     RingBuffer_test.cpp
     SharedBitfield_test.cpp
     Boolean_compilation_test.cpp
+    MultiContext_test.cpp
+    MultiThreading_test.cpp
     
     # regession tests
     Regression_test_82.cpp

--- a/source/tests/glbinding-test/MultiContext_test.cpp
+++ b/source/tests/glbinding-test/MultiContext_test.cpp
@@ -5,15 +5,16 @@
 #include <GLFW/glfw3.h>
 
 #include <glbinding/AbstractFunction.h>
-#include <glbinding/Meta.h>
-#include <glbinding/ContextInfo.h>
 #include <glbinding/Version.h>
 #include <glbinding/Binding.h>
+#include <glbinding/glbinding.h>
+#include <glbinding-aux/ContextInfo.h>
 
 #include <glbinding/gl/gl.h>
 
 using namespace gl;
 using namespace glbinding;
+using namespace aux;
 
 class MultiContext_test : public testing::Test
 {
@@ -54,7 +55,9 @@ TEST_F(MultiContext_test, Test)
     EXPECT_NE(nullptr, window2);
 
     glfwMakeContextCurrent(window1);
-    Binding::initialize(false);
+    glbinding::initialize(0, [](const char * name) {
+        return glfwGetProcAddress(name);
+    });
 
 #ifdef  SYSTEM_WINDOWS
     EXPECT_EQ(Version(3, 2), ContextInfo::version());
@@ -67,7 +70,9 @@ TEST_F(MultiContext_test, Test)
 #endif
 
     glfwMakeContextCurrent(window2);
-    Binding::initialize(false);
+    glbinding::initialize(1, [](const char * name) {
+           return glfwGetProcAddress(name);
+    });
 
     Binding::releaseCurrentContext();
     glfwMakeContextCurrent(window1);

--- a/source/tests/glbinding-test/MultiThreading_test.cpp
+++ b/source/tests/glbinding-test/MultiThreading_test.cpp
@@ -6,10 +6,9 @@
 #include <GLFW/glfw3.h>
 
 #include <glbinding/AbstractFunction.h>
-#include <glbinding/Meta.h>
-#include <glbinding/ContextInfo.h>
 #include <glbinding/Version.h>
 #include <glbinding/Binding.h>
+#include <glbinding/glbinding.h>
 
 #include <glbinding/gl/gl.h>
 
@@ -60,7 +59,9 @@ TEST_F(MultiThreading_test, Test)
     std::thread t1([window1]() 
     {
         glfwMakeContextCurrent(window1);
-        Binding::initialize(false);
+        glbinding::initialize(0, [](const char * name) {
+            return glfwGetProcAddress(name);
+        });
 
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
@@ -82,7 +83,9 @@ TEST_F(MultiThreading_test, Test)
     std::thread t2([window2]() 
     {
         glfwMakeContextCurrent(window2);
-        Binding::initialize(false);
+        glbinding::initialize(1, [](const char * name) {
+            return glfwGetProcAddress(name);
+        });
 
         std::this_thread::sleep_for(std::chrono::milliseconds(4));
 


### PR DESCRIPTION
Found out those test were broken when working on https://github.com/mesonbuild/wrapdb/pull/974. Fixed them for up-to-date glbinding and added to CMake test suite.