### PR TITLE
Intel oneapi support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,11 @@ include(GenerateExportHeader)
 set(WriterCompilerDetectionHeaderFound NOTFOUND)
 # This module is only available with CMake >=3.1, so check whether it could be found
 # BUT in CMake 3.1 this module doesn't recognize AppleClang as compiler, so just use it as of CMake 3.2
+#[[ deprecated CMake module
 if (${CMAKE_VERSION} VERSION_GREATER "3.2")
     include(WriteCompilerDetectionHeader OPTIONAL RESULT_VARIABLE WriterCompilerDetectionHeaderFound)
 endif()
+]]
 
 if (${CMAKE_VERSION} VERSION_GREATER "3.9")
     include(CheckIPOSupported OPTIONAL RESULT_VARIABLE CheckIPOSupportedFound)

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -105,8 +105,10 @@ if (MSVC)
     )
 endif ()
 
-# GCC and Clang compiler options
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND NOT MSVC)
+# GCC, Clang and IntelLLVM compiler options
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR 
+    "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
+    "${CMAKE_CXX_COMPILER_ID}" MATCHES "IntelLLVM" AND NOT MSVC)
     set(DEFAULT_COMPILE_OPTIONS_PRIVATE ${DEFAULT_COMPILE_OPTIONS_PRIVATE}
         #-fno-exceptions # since we use stl and stl is intended to use exceptions, exceptions should not be disabled
 
@@ -145,6 +147,13 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
 
             # -Wreturn-stack-address # gives false positives
         >
+
+        $<$<CXX_COMPILER_ID:IntelLLVM>:
+            -Wmaybe-uninitialized
+            -Wno-unknown-pragmas
+            -Wpedantic
+            -Wreturn-local-addr
+        >         
     )
     set(DEFAULT_COMPILE_OPTIONS_PUBLIC ${DEFAULT_COMPILE_OPTIONS_PUBLIC}
         $<$<PLATFORM_ID:Darwin>:

--- a/source/codegeneration/glbinding-aux_features.h
+++ b/source/codegeneration/glbinding-aux_features.h
@@ -301,8 +301,8 @@
 
 # elif GLBINDING_COMPILER_IS_Intel
 
-#    if (__INTEL_LLVM_COMPILER < 202400)
-#      error Unsupported Intel compiler mimimum version 2024.0
+#    if (__INTEL_LLVM_COMPILER < 20230000)
+#      error Unsupported Intel compiler: mimimum version is 2023.0
 #    endif
 #    define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
 #    define GLBINDING_COMPILER_CXX_CONSTEXPR 1

--- a/source/codegeneration/glbinding-aux_features.h
+++ b/source/codegeneration/glbinding-aux_features.h
@@ -302,7 +302,7 @@
 # elif GLBINDING_COMPILER_IS_Intel
 
 #    if (__INTEL_LLVM_COMPILER < 202400)
-#      error Unsupported Intel compiler: mimimum version is 2024.0
+#      error Unsupported Intel compiler mimimum version 2024.0
 #    endif
 #    define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
 #    define GLBINDING_COMPILER_CXX_CONSTEXPR 1

--- a/source/codegeneration/glbinding_features.h
+++ b/source/codegeneration/glbinding_features.h
@@ -301,8 +301,8 @@
 
 # elif GLBINDING_COMPILER_IS_Intel
 
-#    if (__INTEL_LLVM_COMPILER < 202400)
-#      error Unsupported Intel compiler: mimimum version is 2024.0
+#    if (__INTEL_LLVM_COMPILER < 20230000)
+#      error Unsupported Intel compiler: mimimum version is 2023.0
 #    endif
 #    define GLBINDING_COMPILER_CXX_ATTRIBUTE_DEPRECATED 1
 #    define GLBINDING_COMPILER_CXX_CONSTEXPR 1


### PR DESCRIPTION
Hi there,
Just an initial draft proposal in order to enable support for the new [Intel oneAPI compiler](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2024-0/overview.html).
Since the CMake module `WriteCompilerDetectionHeader` is deprecated I just took the files `glbinding_features.h` and `glbinding-aux_features.h` as it were and updated them with the compiler support.
Thanks for your time and attention.