### PR TITLE
fix compilation with clang-cl

### DIFF
--- a/source/glbinding/include/glbinding/gl/types.h
+++ b/source/glbinding/include/glbinding/gl/types.h
@@ -10,8 +10,8 @@
 #include <KHR/khrplatform.h>
 
 
-#ifdef _MSC_VER
-#define GL_APIENTRY __stdcall
+#ifdef WINAPI
+#define GL_APIENTRY WINAPI
 #else
 #define GL_APIENTRY
 #endif


### PR DESCRIPTION
__stdcall is supported by MinGW as well.